### PR TITLE
Added a --no-carriage-return flag and made appending a CR (Return/Enter) the default once again

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ struct Args {
     /// Enable keyboard output
     #[arg(short, long, default_value_t = false)]
     keyboard: bool,
+    /// Disable appending a CR character (Return/Enter) after the barcode contents
+    #[arg(short, long, default_value_t = false)]
+    no_carriage_return: bool,
 }
 
 const LOG_UNSAFE_CHARS: &'static AsciiSet = &rfc3986::CONTROLS.add(b'\\').add(b'"');
@@ -92,6 +95,9 @@ async fn main() -> bluer::Result<()> {
 
             if args.keyboard {
                 enigo.text(s).unwrap_or_else(|e| error!("{}", e));
+                if !args.no_carriage_return {
+                    enigo.text("\r").unwrap_or_else(|e| error!("{}", e));
+                }
             }
         }
     }


### PR DESCRIPTION
I mentioned this as a possible TODO in my last PR but only got to implementing it now.

I think the short `-n` flag name is great for this as it's already commonly used for some CLI tools that append newlines by default, but I'm not sure about the long name of the flag. Is `--no-cr` a good name, would `--no-newline` be more clear (though here we're adding a `\r` and not a `\n` so not sure if that's accurate).

I also am not sure if the wording of the help string for the new option is the best so lmk what you think :)